### PR TITLE
Remove rake db:seed from README and Add pry-rails to gemfile

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,12 +1,12 @@
 language: ruby
-
+cache: bundler
 rvm:
   - "2.3"
 
 env:
   - DB=postgresql
-  
-script: 
+
+script:
   - RAILS_ENV=test bundle exec rake db:migrate --trace
   - bundle exec rake db:test:prepare
   - bundle exec rspec

--- a/Gemfile
+++ b/Gemfile
@@ -40,7 +40,7 @@ gem 'materialize-form'
 group :development, :test do
   # Call 'byebug' anywhere in the code to stop execution and get a debugger console
   gem 'byebug', platforms: [:mri, :mingw, :x64_mingw]
-  gem 'pry'
+  gem 'pry-rails'
   gem 'launchy'
   gem 'rspec-rails'
   gem 'capybara'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -114,6 +114,8 @@ GEM
       coderay (~> 1.1.0)
       method_source (~> 0.8.1)
       slop (~> 3.4)
+    pry-rails (0.3.6)
+      pry (>= 0.10.4)
     public_suffix (3.0.0)
     puma (3.10.0)
     rack (2.0.3)
@@ -229,7 +231,7 @@ DEPENDENCIES
   materialize-form
   materialize-sass
   pg (~> 0.18)
-  pry
+  pry-rails
   puma (~> 3.7)
   rails (~> 5.1.4)
   rspec-rails
@@ -242,4 +244,4 @@ DEPENDENCIES
   web-console (>= 3.3.0)
 
 BUNDLED WITH
-   1.16.0.pre.2
+   1.16.0.pre.3

--- a/README.md
+++ b/README.md
@@ -16,8 +16,7 @@ Site built with Ruby on Rails utilizing ActiveRecord on Postgresql. Site is prim
   * cd into it
   * ```bundle install```
   * ```rake db:setup```
-  * ```rake db:seed```
-  * ```rails server```
+  * ```rails s```
   * visit ```localhost:30000```
 
 ### Visit Online

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -34,7 +34,7 @@ ActiveRecord::Schema.define(version: 20170917211050) do
     t.string "name"
     t.text "description"
     t.float "price"
-    t.string "image_path"
+    t.string "image_path", default: "garbage.jpg"
     t.boolean "active", default: true
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false


### PR DESCRIPTION
Additions: Added `pry-rails` to gemfile. It does the same thing as just adding `pry` except it also allows the use of pry in `rails c`. 


User Story:


Concerns (code location):
Also removed `rake db:seed` from README as it is redundant with the use of `rake db:setup`
Also added `cache: bundler` to `.travis.yml`. It *should* speed up the CI


Mentions to collaborators: @amhursh @blsrofe @JunePaloma 


Notes(if applicable):



