### PR TITLE
Add carousel functionality for categories on root page

### DIFF
--- a/app/controllers/categories_controller.rb
+++ b/app/controllers/categories_controller.rb
@@ -3,7 +3,7 @@
 class CategoriesController < ApplicationController
 
   def show
-    @category = Category.find_by(name: params[:category_name])
+    @category = Category.find(params[:id])
   end
 
 end

--- a/app/views/welcome/index.html.erb
+++ b/app/views/welcome/index.html.erb
@@ -7,11 +7,6 @@
   <script src="https://maxcdn.bootstrapcdn.com/bootstrap/3.3.7/js/bootstrap.min.js"></script>
 </head>
 
-<div>
-  <% @categories.each do |category|  %>
-    <%= link_to category.name, category_path(category)  %>
-  <% end %>
-</div>
 
 <div>
   <%= link_to 'View Stores', stores_path %>
@@ -30,8 +25,8 @@
     <!-- Wrapper for slides -->
     <div class="carousel-inner">
       <% @categories.each_with_index do |slide, i| %>
-        <div class="item #{active if i == 0}">
-            <%= image_tag slide.image %>
+        <div class="item <% if i == 0 %>active<% end %> ">
+            <%= image_tag slide.image, class: 'resonsive-img' %>
           <div class="carousel-caption">
             <h4> <%= slide.name %> </h4>
             <p> <%= button_to "info_outline", category_path(slide), class: "btn-large black large material-icons" , method: 'get' %> </p>


### PR DESCRIPTION
Additions: 
Add carousel. Would like to implement a more static image in the carousel so it's not constantly resizing. I will make an issue on the board about that for later refactor.

User Story:
3

Concerns (code location):
Need refactor for the image sizes to be static

Mentions to collaborators:
@amhursh @blsrofe @JunePaloma 

Notes(if applicable):
Had to change how the link to the category show page was working. 


