### PR TITLE
Store request

### DIFF
--- a/app/controllers/admin/store_requests_controller.rb
+++ b/app/controllers/admin/store_requests_controller.rb
@@ -12,4 +12,12 @@ class Admin::StoreRequestsController < Admin::BaseController
     end
   end
 
+  def approve
+    request = StoreRequest.find(params[:store_request_id])
+    if StoreRequestConverter.new(request).approved
+      flash[:good_message] = "Created Store #{request.name} and Admin #{request.user.name}."
+      redirect_to admin_store_requests_path
+    end
+  end
+
 end

--- a/app/controllers/admin/store_requests_controller.rb
+++ b/app/controllers/admin/store_requests_controller.rb
@@ -4,4 +4,12 @@ class Admin::StoreRequestsController < Admin::BaseController
     @requests = StoreRequest.all
   end
 
+  def decline
+    request = StoreRequest.find(params[:store_request_id])
+    if StoreRequestConverter.new(request).declined
+      flash[:good_message] = "Store Request #{request.id} declined!"
+      redirect_to admin_store_requests_path
+    end
+  end
+
 end

--- a/app/controllers/admin/store_requests_controller.rb
+++ b/app/controllers/admin/store_requests_controller.rb
@@ -1,0 +1,7 @@
+class Admin::StoreRequestsController < Admin::BaseController
+
+  def index
+    @requests = StoreRequest.all
+  end
+
+end

--- a/app/controllers/admin/store_requests_controller.rb
+++ b/app/controllers/admin/store_requests_controller.rb
@@ -15,9 +15,16 @@ class Admin::StoreRequestsController < Admin::BaseController
   def approve
     request = StoreRequest.find(params[:store_request_id])
     if StoreRequestConverter.new(request).approved
-      flash[:good_message] = "Created Store #{request.name} and Admin #{request.user.name}."
+      flash[:good_message] = "Created Store #{request.name} and Admin #{user_or_operator(request).name}."
       redirect_to admin_store_requests_path
     end
   end
+
+  private
+
+    def user_or_operator(request)
+      return request.operator if request.operator
+      return request.user if request.user
+    end
 
 end

--- a/app/controllers/store_requests_controller.rb
+++ b/app/controllers/store_requests_controller.rb
@@ -1,0 +1,7 @@
+class StoreRequestsController < ApplicationController
+
+  def new
+    
+  end
+
+end

--- a/app/controllers/store_requests_controller.rb
+++ b/app/controllers/store_requests_controller.rb
@@ -1,7 +1,7 @@
 class StoreRequestsController < ApplicationController
 
   def new
-    
+    @requests = StoreRequest.new
   end
 
 end

--- a/app/controllers/store_requests_controller.rb
+++ b/app/controllers/store_requests_controller.rb
@@ -1,7 +1,7 @@
 class StoreRequestsController < ApplicationController
 
   def new
-    @requests = StoreRequest.new
+    @request = StoreRequest.new
   end
 
 end

--- a/app/controllers/store_requests_controller.rb
+++ b/app/controllers/store_requests_controller.rb
@@ -5,9 +5,9 @@ class StoreRequestsController < ApplicationController
   end
 
   def create
-    user = current_user || current_operator
+    user = set_user
     request = StoreRequest.new(store_request_params)
-    request.update(user_id: user.id)
+    update_request(request, user)
     if request.save
       flash[:good_message] = "Successfully submitted a store request"
       redirect_to store_requests_path
@@ -18,14 +18,25 @@ class StoreRequestsController < ApplicationController
   end
 
   def index
-    user = current_user || current_operator
-    @requests = StoreRequest.where(user_id: user.id)
+    user = set_user
+    @requests = StoreRequest.where(user_id: user.id) if current_user
+    @requests = StoreRequest.where(operator_id: user.id) if current_operator
   end
 
   private
 
     def store_request_params
       params.require(:store_request).permit(:name, :description)
+    end
+
+    def set_user
+      return current_user if current_user
+      return current_operator if current_operator
+    end
+
+    def update_request(request, user)
+      request.update(user_id: user.id) if user == current_user
+      request.update(operator_id: user.id) if user == current_operator
     end
 
 end

--- a/app/controllers/store_requests_controller.rb
+++ b/app/controllers/store_requests_controller.rb
@@ -4,4 +4,28 @@ class StoreRequestsController < ApplicationController
     @request = StoreRequest.new
   end
 
+  def create
+    user = current_user || current_operator
+    request = StoreRequest.new(store_request_params)
+    request.update(user_id: user.id)
+    if request.save
+      flash[:good_message] = "Successfully submitted a store request"
+      redirect_to store_requests_path
+    else
+      flash[:bad_message] = "Request Failed"
+      redirect_to new_store_request_path
+    end
+  end
+
+  def index
+    user = current_user || current_operator
+    @requests = StoreRequest.where(user_id: user.id)
+  end
+
+  private
+
+    def store_request_params
+      params.require(:store_request).permit(:name, :description)
+    end
+
 end

--- a/app/models/operator.rb
+++ b/app/models/operator.rb
@@ -2,6 +2,7 @@ class Operator < ApplicationRecord
   has_secure_password
   has_many :store_operators
   has_many :stores, through: :store_operators
+  has_many :store_requests
   enum role: ["manager", "admin", "platform_admin"]
 
   def store_admin?

--- a/app/models/store_request.rb
+++ b/app/models/store_request.rb
@@ -1,4 +1,5 @@
 class StoreRequest < ApplicationRecord
-  belongs_to :user
+  belongs_to :user, optional: true
+  belongs_to :operator, optional: true
   enum status: ["pending", "declined", "approved"]
 end

--- a/app/models/store_request.rb
+++ b/app/models/store_request.rb
@@ -1,0 +1,4 @@
+class StoreRequest < ApplicationRecord
+  belongs_to :user
+  enum status: ["pending", "declined", "approved"]
+end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -1,6 +1,7 @@
 class User < ApplicationRecord
   has_secure_password
   has_many :orders
+  has_many :store_requests
 
   validates :username, presence: :true, uniqueness: :true
   validates :password_digest, presence: :true

--- a/app/services/permissions_service.rb
+++ b/app/services/permissions_service.rb
@@ -9,7 +9,7 @@ class PermissionsService
     return true if all_visitor_permissions
     if user.platform_admin?
       return true if platform_admin_permissions
-      return true if business_admin_persmissions
+      return true if business_admin_permissions
       return true if business_manager_permissions
       return true if registered_user_permissions
     elsif user.admin?

--- a/app/services/permissions_service.rb
+++ b/app/services/permissions_service.rb
@@ -44,7 +44,7 @@ class PermissionsService
   def platform_admin_permissions
     return true if controller == "dashboard" && action.in?(["index"])
     return true if controller == "stores" && action.in?(%w(new create destroy))
-    return true if controller == "admin/store_requests" && action.in?(%w(index))
+    return true if controller == "admin/store_requests" && action.in?(%w(index decline))
   end
 
   def business_admin_permissions

--- a/app/services/permissions_service.rb
+++ b/app/services/permissions_service.rb
@@ -44,7 +44,7 @@ class PermissionsService
   def platform_admin_permissions
     return true if controller == "dashboard" && action.in?(["index"])
     return true if controller == "stores" && action.in?(%w(new create destroy))
-    return true if controller == "admin/store_requests" && action.in?(%w(index decline))
+    return true if controller == "admin/store_requests" && action.in?(%w(index decline approve))
   end
 
   def business_admin_permissions

--- a/app/services/permissions_service.rb
+++ b/app/services/permissions_service.rb
@@ -63,5 +63,6 @@ class PermissionsService
   def registered_user_permissions
     return true if controller == "orders" && action.in?(["index", "show", "create"])
     return true if controller == "users" && action.in?(%w(edit update show))
+    return true if controller == "store_requests" && action.in?(%w(new))
   end
 end

--- a/app/services/permissions_service.rb
+++ b/app/services/permissions_service.rb
@@ -63,6 +63,6 @@ class PermissionsService
   def registered_user_permissions
     return true if controller == "orders" && action.in?(["index", "show", "create"])
     return true if controller == "users" && action.in?(%w(edit update show))
-    return true if controller == "store_requests" && action.in?(%w(new))
+    return true if controller == "store_requests" && action.in?(%w(new create index))
   end
 end

--- a/app/services/permissions_service.rb
+++ b/app/services/permissions_service.rb
@@ -44,6 +44,7 @@ class PermissionsService
   def platform_admin_permissions
     return true if controller == "dashboard" && action.in?(["index"])
     return true if controller == "stores" && action.in?(%w(new create destroy))
+    return true if controller == "admin/store_requests" && action.in?(%w(index))
   end
 
   def business_admin_permissions

--- a/app/services/store_request_converter.rb
+++ b/app/services/store_request_converter.rb
@@ -4,7 +4,7 @@ class StoreRequestConverter
     @request        = request
     @name           = request.name
     @description    = request.description
-    @attached_user  = request.user
+    @attached_user  = request.user || request.operator
   end
 
   def declined
@@ -32,10 +32,14 @@ class StoreRequestConverter
   end
 
   def upgrade_user(store)
-    op = Operator.create(name: attached_user.name,
-                    user_name: attached_user.username,
-                    email: attached_user.email,
-                    password_digest: attached_user.password_digest)
+    if attached_user.class == User
+      op = Operator.create(name: attached_user.name,
+                           user_name: attached_user.username,
+                           email: attached_user.email,
+                           password_digest: attached_user.password_digest)
+    else
+      op = attached_user
+    end
     link_to_store(store, op)
   end
 

--- a/app/services/store_request_converter.rb
+++ b/app/services/store_request_converter.rb
@@ -1,0 +1,24 @@
+class StoreRequestConverter
+
+  def initialize(request)
+    @request        = request
+    @name           = request.name
+    @description    = request.description
+    @attached_user  = request.user
+  end
+
+  def declined
+    return true if request.declined!
+  end
+
+  private
+
+  attr_reader :name,
+              :description,
+              :attached_user,
+              :request
+
+  def slug
+    name.parameterize
+  end
+end

--- a/app/services/store_request_converter.rb
+++ b/app/services/store_request_converter.rb
@@ -11,6 +11,15 @@ class StoreRequestConverter
     return true if request.declined!
   end
 
+  def approved
+    store = Store.new(name: name, description: description, slug: slug)
+    if store.save
+      upgrade_user(store)
+      request.approved!
+      return true
+    end
+  end
+
   private
 
   attr_reader :name,
@@ -21,4 +30,17 @@ class StoreRequestConverter
   def slug
     name.parameterize
   end
+
+  def upgrade_user(store)
+    op = Operator.create(name: attached_user.name,
+                    user_name: attached_user.username,
+                    email: attached_user.email,
+                    password_digest: attached_user.password_digest)
+    link_to_store(store, op)
+  end
+
+  def link_to_store(store, operator)
+    StoreOperator.create(store_id: store.id, operator_id: operator.id)
+  end
+
 end

--- a/app/views/admin/dashboard/index.html.erb
+++ b/app/views/admin/dashboard/index.html.erb
@@ -1,5 +1,17 @@
 <h3>Admin Dashboard</h3>
 
+<% if current_operator.platform_admin? %>
+<div class="container">
+  <div class="row">
+    <div class="col s12">
+      <div class="center-align">
+        <%= button_to 'View Store Requests', admin_store_requests_path, method: :get, class: "btn-large black large" %>
+      </div>
+    </div>
+  </div>
+</div>
+<% end %>
+
 <p>Ordered: <%= @all_orders.ordered.count %> </p>
 <p>Paid: <%= @all_orders.paid.count %> </p>
 <p>Cancelled: <%= @all_orders.cancelled.count %> </p>

--- a/app/views/admin/store_requests/index.html.erb
+++ b/app/views/admin/store_requests/index.html.erb
@@ -4,7 +4,7 @@
   <thead>
     <tr>
       <th>Request</th>
-      <th>User</th>
+      <th>User/Operator</th>
       <th>Store Name</th>
       <th>Request Placed On:</th>
       <th>Request Updated At: </th>
@@ -19,7 +19,11 @@
       <div class="request<%= request.id %>">
         <tr>
         <td><%= request.id %></td>
+        <% if request.user %>
         <td><%= request.user.username %></td>
+        <% else %>
+        <td><%= request.operator.user_name %></td>
+        <% end %>
         <td><%= request.name %></td>
         <td><%= request.created_at.to_formatted_s(:long_ordinal) %> </td>
         <td><%= request.updated_at.to_formatted_s(:long_ordinal) %> </td>

--- a/app/views/admin/store_requests/index.html.erb
+++ b/app/views/admin/store_requests/index.html.erb
@@ -1,0 +1,38 @@
+<h1>All Store Requests</h1>
+
+<table>
+  <thead>
+    <tr>
+      <th>Request</th>
+      <th>User</th>
+      <th>Store Name</th>
+      <th>Request Placed On:</th>
+      <th>Request Updated At: </th>
+      <th>Status</th>
+      <th colspan="2">Action</th>
+    </tr>
+
+  </thead>
+
+  <tbody class="table">
+    <% @requests.each do |request| %>
+      <div class="request<%= request.id %>">
+        <tr>
+        <td><%= request.id %></td>
+        <td><%= request.user.username %></td>
+        <td><%= request.name %></td>
+        <td><%= request.created_at.to_formatted_s(:long_ordinal) %> </td>
+        <td><%= request.updated_at.to_formatted_s(:long_ordinal) %> </td>
+        <td><%= request.status.humanize %></td>
+        <% if request.status == 'pending' %>
+        <td><%= button_to "Approve", approve_store_request_path(request), class: "waves-effect waves-light btn black" %></td>
+        <td><%= button_to "Decline", decline_store_request_path(request), class: "waves-effect waves-light btn black" %></td>
+        <% elsif request.status == 'approved' %>
+        <td><%= button_to "Approved", approve_store_request_path(request), class: "waves-effect waves-light btn disabled" %></td>
+        <% else %>
+        <td><%= button_to "Declined", approve_store_request_path(request), class: "waves-effect waves-light btn disabled" %></td>
+        <% end %>
+      </div>
+      <% end %>
+    </tbody>
+  </table>

--- a/app/views/store_requests/index.html.erb
+++ b/app/views/store_requests/index.html.erb
@@ -1,0 +1,28 @@
+<h1>Your Store Requests</h1>
+
+<table>
+  <thead>
+    <tr>
+      <th>Request</th>
+      <th>Store Name</th>
+      <th>Request Placed On:</th>
+      <th>Request Updated At: </th>
+      <th>Status</th>
+      <th colspan="3"></th>
+    </tr>
+
+  </thead>
+
+  <tbody class="table">
+    <% @requests.each do |request| %>
+      <div class="request<%= request.id %>">
+        <tr>
+        <td><%= request.id %></td>
+        <td><%= request.name %></td>
+        <td><%= request.created_at.to_formatted_s(:long_ordinal) %> </td>
+        <td><%= request.updated_at.to_formatted_s(:long_ordinal) %> </td>
+        <td><%= request.status.humanize %></td>
+      </div>
+      <% end %>
+    </tbody>
+  </table>

--- a/app/views/store_requests/new.html.erb
+++ b/app/views/store_requests/new.html.erb
@@ -1,0 +1,8 @@
+<%= form_for(@request) do |f| %>
+	<%= f.label :name, "Name" %>
+	<%= f.text_field :name %>
+	<%= f.label :description, "Description" %>
+	<%= f.text_box :description %>
+	<%= f.submit "Submit" %>
+<% end %>
+  

--- a/app/views/store_requests/new.html.erb
+++ b/app/views/store_requests/new.html.erb
@@ -2,7 +2,7 @@
 	<%= f.label :name, "Name" %>
 	<%= f.text_field :name %>
 	<%= f.label :description, "Description" %>
-	<%= f.text_box :description %>
+	<%= f.text_area :description %>
 	<%= f.submit "Submit" %>
 <% end %>
   

--- a/app/views/welcome/index.html.erb
+++ b/app/views/welcome/index.html.erb
@@ -7,7 +7,16 @@
   <script src="https://maxcdn.bootstrapcdn.com/bootstrap/3.3.7/js/bootstrap.min.js"></script>
 </head>
 
-
-<div>
-  <%= link_to 'View Stores', stores_path %>
+<div class="container">
+	<div class="row">
+		<div class="col s12">
+			<div class="center-align">
+			  <%= button_to 'View Stores', stores_path, method: :get, class: "btn-large black large" %>
+			</div>
+			<div class="center-align">
+				<%= button_to 'Request a Store', new_store_request_path, method: :get, class: "btn-large black large" %>
+			</div>
+		</div>
+	</div>
 </div>
+

--- a/app/views/welcome/index.html.erb
+++ b/app/views/welcome/index.html.erb
@@ -13,9 +13,11 @@
 			<div class="center-align">
 			  <%= button_to 'View Stores', stores_path, method: :get, class: "btn-large black large" %>
 			</div>
+			<% if current_user || current_operator %>
 			<div class="center-align">
 				<%= button_to 'Request a Store', new_store_request_path, method: :get, class: "btn-large black large" %>
 			</div>
+			<% end %>
 		</div>
 	</div>
 </div>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -13,7 +13,7 @@ Rails.application.routes.draw do
 
   resources :orders, only: [:index, :show, :create]
 
-  resources :store_requests, only: [:new, :create]
+  resources :store_requests, only: [:new, :create, :index]
 
   namespace :api do
     namespace :v1 do

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -13,7 +13,7 @@ Rails.application.routes.draw do
 
   resources :orders, only: [:index, :show, :create]
 
-  resources :store_requests, only: [:new]
+  resources :store_requests, only: [:new, :create]
 
   namespace :api do
     namespace :v1 do

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -27,6 +27,7 @@ Rails.application.routes.draw do
     resources :items, except: [:destroy]
     resources :stores, only: [:edit, :update]
     resources :operators
+    resources :store_requests, only: [:index]
     # get '/dashboard', to: "admindashboard#dashboard"
   end
 

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -13,6 +13,8 @@ Rails.application.routes.draw do
 
   resources :orders, only: [:index, :show, :create]
 
+  resources :store_requests, only: [:new]
+
   namespace :api do
     namespace :v1 do
       resources :merchants, only: [:index]

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -57,5 +57,8 @@ Rails.application.routes.draw do
   post '/orders/paid/:order_id', to: "orders#paid", as: "order_paid"
   post '/orders/completed/:order_id', to: "orders#completed", as: "order_completed"
 
+  post '/store_requests/approve/:store_request_id', to: 'admin/store_requests#approve', as: 'approve_store_request'
+  post '/store_requests/decline/:store_request_id', to: 'admin/store_requests#decline', as: 'decline_store_request'  
+
   get '/:store_slug', to: 'stores#show', as: 'store'
 end

--- a/db/migrate/20171026053444_create_store_requests.rb
+++ b/db/migrate/20171026053444_create_store_requests.rb
@@ -5,6 +5,8 @@ class CreateStoreRequests < ActiveRecord::Migration[5.1]
       t.string :description
       t.integer :status, default: 0
       t.references :user, foreign_key: true
+
+      t.timestamps
     end
   end
 end

--- a/db/migrate/20171026053444_create_store_requests.rb
+++ b/db/migrate/20171026053444_create_store_requests.rb
@@ -1,0 +1,10 @@
+class CreateStoreRequests < ActiveRecord::Migration[5.1]
+  def change
+    create_table :store_requests do |t|
+      t.string :name
+      t.string :description
+      t.integer :status, default: 0
+      t.references :user, foreign_key: true
+    end
+  end
+end

--- a/db/migrate/20171026160855_add_operator_to_store_requests.rb
+++ b/db/migrate/20171026160855_add_operator_to_store_requests.rb
@@ -1,0 +1,5 @@
+class AddOperatorToStoreRequests < ActiveRecord::Migration[5.1]
+  def change
+    add_reference :store_requests, :operator, foreign_key: true
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20171026053444) do
+ActiveRecord::Schema.define(version: 20171026160855) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -93,6 +93,8 @@ ActiveRecord::Schema.define(version: 20171026053444) do
     t.bigint "user_id"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
+    t.bigint "operator_id"
+    t.index ["operator_id"], name: "index_store_requests_on_operator_id"
     t.index ["user_id"], name: "index_store_requests_on_user_id"
   end
 
@@ -133,5 +135,6 @@ ActiveRecord::Schema.define(version: 20171026053444) do
   add_foreign_key "orders", "users"
   add_foreign_key "store_operators", "operators"
   add_foreign_key "store_operators", "stores"
+  add_foreign_key "store_requests", "operators"
   add_foreign_key "store_requests", "users"
 end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20171024024137) do
+ActiveRecord::Schema.define(version: 20171026053444) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -72,6 +72,8 @@ ActiveRecord::Schema.define(version: 20171024024137) do
     t.integer "status", default: 0
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
+    t.bigint "store_id"
+    t.index ["store_id"], name: "index_orders_on_store_id"
     t.index ["user_id"], name: "index_orders_on_user_id"
   end
 
@@ -82,6 +84,14 @@ ActiveRecord::Schema.define(version: 20171024024137) do
     t.datetime "updated_at", null: false
     t.index ["operator_id"], name: "index_store_operators_on_operator_id"
     t.index ["store_id"], name: "index_store_operators_on_store_id"
+  end
+
+  create_table "store_requests", force: :cascade do |t|
+    t.string "name"
+    t.string "description"
+    t.integer "status", default: 0
+    t.bigint "user_id"
+    t.index ["user_id"], name: "index_store_requests_on_user_id"
   end
 
   create_table "stores", force: :cascade do |t|
@@ -117,7 +127,9 @@ ActiveRecord::Schema.define(version: 20171024024137) do
   add_foreign_key "item_orders", "orders"
   add_foreign_key "items", "categories"
   add_foreign_key "items", "stores"
+  add_foreign_key "orders", "stores"
   add_foreign_key "orders", "users"
   add_foreign_key "store_operators", "operators"
   add_foreign_key "store_operators", "stores"
+  add_foreign_key "store_requests", "users"
 end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -91,6 +91,8 @@ ActiveRecord::Schema.define(version: 20171026053444) do
     t.string "description"
     t.integer "status", default: 0
     t.bigint "user_id"
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
     t.index ["user_id"], name: "index_store_requests_on_user_id"
   end
 

--- a/spec/factories/store_requests.rb
+++ b/spec/factories/store_requests.rb
@@ -1,0 +1,12 @@
+FactoryGirl.define do
+  factory :store_request do
+    sequence :name do |n|
+      "#{n}store_request_name"
+    end
+    sequence :description do |x|
+      "#{x}store_request_description"
+    end
+    status 0
+    user
+  end
+end

--- a/spec/factories/store_requests.rb
+++ b/spec/factories/store_requests.rb
@@ -7,6 +7,7 @@ FactoryGirl.define do
       "#{x}store_request_description"
     end
     status 0
-    user
+    user nil
+    operator nil
   end
 end

--- a/spec/features/platform_admin/platform_admin_can_view_store_requests_and_approve_spec.rb
+++ b/spec/features/platform_admin/platform_admin_can_view_store_requests_and_approve_spec.rb
@@ -28,8 +28,9 @@ describe 'Platform Admin can view all store requests' do
 
     within(".request#{sr1.id}") do
       click_on 'Decline', match: :first
-      expect(page).to have_content("Declined")
     end
+
+    expect(page).to have_content("Declined")
 
     within(".request#{sr2.id}") do
       click_on 'Approve', match: :first

--- a/spec/features/platform_admin/platform_admin_can_view_store_requests_and_approve_spec.rb
+++ b/spec/features/platform_admin/platform_admin_can_view_store_requests_and_approve_spec.rb
@@ -19,20 +19,20 @@ describe 'Platform Admin can view all store requests' do
     
     expect(page).to have_content("#{sr1.name}")
     expect(page).to have_content("#{sr1.id}")
-    expect(page).to have_content("#{sr1.user}")
+    expect(page).to have_content("#{sr1.user.username}")
     expect(page).to have_content("#{sr1.updated_at.to_formatted_s(:long_ordinal)}")
     expect(page).to have_content("#{sr1.created_at.to_formatted_s(:long_ordinal)}")
     expect(page).to have_content("Pending", count: 3)
     expect(page).to have_selector(:link_or_button, 'Approve', count: 3)
     expect(page).to have_selector(:link_or_button, 'Decline', count: 3)
 
-    within("request#{sr1.id}") do
-      click_on 'Decline'
+    within(".request#{sr1.id}") do
+      click_on 'Decline', match: :first
       expect(page).to have_content("Declined")
     end
 
-    within("request#{sr2.id}") do
-      click_on 'Approve'
+    within(".request#{sr2.id}") do
+      click_on 'Approve', match: :first
       expect(page).to have_content("Approved")
     end
 

--- a/spec/features/platform_admin/platform_admin_can_view_store_requests_and_approve_spec.rb
+++ b/spec/features/platform_admin/platform_admin_can_view_store_requests_and_approve_spec.rb
@@ -1,7 +1,7 @@
 require 'rails_helper'
 
 describe 'Platform Admin can view all store requests' do
-  scenario 'and can approve or decline individual store requests' do
+  scenario 'and can approve or decline individual store requests for a user' do
     admin = create(:operator)
     admin.platform_admin!
     allow_any_instance_of(ApplicationController).to receive(:current_operator).and_return(admin)
@@ -39,6 +39,52 @@ describe 'Platform Admin can view all store requests' do
     expect(page).to have_content("Approved")
 
     expect(page).to have_content("Created Store #{sr2.name} and Admin #{sr2.user.name}.")
+
+    visit "/#{sr2.name}"
+
+    expect(current_path).to eq store_path("#{sr2.name}")
+
+    expect(page).to have_content("#{sr2.name}")
+  end
+
+  scenario 'and can approve or decline individual store requests for an admin' do
+    admin = create(:operator)
+    admin.platform_admin!
+    allow_any_instance_of(ApplicationController).to receive(:current_operator).and_return(admin)
+
+    operator = create(:operator)
+    sr1 = create(:store_request, operator: operator)
+    sr2 = create(:store_request, operator: operator)
+    sr3 = create(:store_request, operator: operator)
+
+    visit admin_dashboard_index_path
+
+    click_on "View Store Requests"
+
+    expect(current_path).to eq admin_store_requests_path
+
+    expect(page).to have_content("#{sr1.name}")
+    expect(page).to have_content("#{sr1.id}")
+    expect(page).to have_content("#{sr1.operator.user_name}")
+    expect(page).to have_content("#{sr1.updated_at.to_formatted_s(:long_ordinal)}")
+    expect(page).to have_content("#{sr1.created_at.to_formatted_s(:long_ordinal)}")
+    expect(page).to have_content("Pending", count: 3)
+    expect(page).to have_selector(:link_or_button, 'Approve', count: 3)
+    expect(page).to have_selector(:link_or_button, 'Decline', count: 3)
+
+    within(".request#{sr1.id}") do
+      click_on 'Decline', match: :first
+    end
+
+    expect(page).to have_content("Declined")
+
+    within(".request#{sr2.id}") do
+      click_on 'Approve', match: :first
+    end
+
+    expect(page).to have_content("Approved")
+
+    expect(page).to have_content("Created Store #{sr2.name} and Admin #{sr2.operator.name}.")
 
     visit "/#{sr2.name}"
 

--- a/spec/features/platform_admin/platform_admin_can_view_store_requests_and_approve_spec.rb
+++ b/spec/features/platform_admin/platform_admin_can_view_store_requests_and_approve_spec.rb
@@ -34,10 +34,11 @@ describe 'Platform Admin can view all store requests' do
 
     within(".request#{sr2.id}") do
       click_on 'Approve', match: :first
-      expect(page).to have_content("Approved")
     end
 
-    expect(page).to have_content("Created Store #{sr2.name} and Admin #{sr2.user.name}")
+    expect(page).to have_content("Approved")
+
+    expect(page).to have_content("Created Store #{sr2.name} and Admin #{sr2.user.name}.")
 
     visit "/#{sr2.name}"
 

--- a/spec/features/platform_admin/platform_admin_can_view_store_requests_and_approve_spec.rb
+++ b/spec/features/platform_admin/platform_admin_can_view_store_requests_and_approve_spec.rb
@@ -1,0 +1,47 @@
+require 'rails_helper'
+
+describe 'Platform Admin can view all store requests' do
+  scenario 'and can approve or decline individual store requests' do
+    admin = create(:operator)
+    admin.platform_admin!
+    allow_any_instance_of(ApplicationController).to receive(:current_operator).and_return(admin)
+
+    user = create(:user)
+    sr1 = create(:store_request, user: user)
+    sr2 = create(:store_request, user: user)
+    sr3 = create(:store_request, user: user)
+
+    visit admin_dashboard_index_path
+
+    click_on "View Store Requests"
+
+    expect(current_path).to eq admin_store_requests_path
+    
+    expect(page).to have_content("#{sr1.name}")
+    expect(page).to have_content("#{sr1.id}")
+    expect(page).to have_content("#{sr1.user}")
+    expect(page).to have_content("#{sr1.updated_at.to_formatted_s(:long_ordinal)}")
+    expect(page).to have_content("#{sr1.created_at.to_formatted_s(:long_ordinal)}")
+    expect(page).to have_content("Pending", count: 3)
+    expect(page).to have_selector(:link_or_button, 'Approve', count: 3)
+    expect(page).to have_selector(:link_or_button, 'Decline', count: 3)
+
+    within("request#{sr1.id}") do
+      click_on 'Decline'
+      expect(page).to have_content("Declined")
+    end
+
+    within("request#{sr2.id}") do
+      click_on 'Approve'
+      expect(page).to have_content("Approved")
+    end
+
+    expect(page).to have_content("Created Store #{sr2.name} and Admin #{sr2.user.name}")
+
+    visit "/#{sr2.name}"
+
+    expect(current_path).to eq store_path("#{sr2.name}")
+
+    expect(page).to have_content("#{sr2.name}")
+  end
+end

--- a/spec/features/stores/user_visits_root_page_spec.rb
+++ b/spec/features/stores/user_visits_root_page_spec.rb
@@ -16,7 +16,6 @@ feature 'User' do
       visit root_path
 
       expect(page).to have_selector(:link_or_button, 'View Stores')
-      page.assert_selector(:css, 'a[href="/stores"]')
     end
   end
 end

--- a/spec/features/users/user_can_initiate_a_request_for_a_new_store_spec.rb
+++ b/spec/features/users/user_can_initiate_a_request_for_a_new_store_spec.rb
@@ -1,0 +1,24 @@
+require 'rails_helper'
+
+describe 'Registered user can request a new store' do
+  scenario 'and can see the status of their requests' do
+    user = create(:user)
+    allow_any_instance_of(ApplicationController).to receive(:current_user).and_return(user)
+
+    visit '/'
+
+    click_on 'Request a Store'
+
+    expect(current_path).to eq new_store_request_path
+
+    fill_in 'store_request[name]', with: 'Cool Store'
+    fill_in 'store_request[description]', with: 'This is a cool store'
+    click_on 'Submit'
+
+    expect(current_path).to eq store_requests_path
+
+    expect(page).to have_content("Cool Store")
+    expect(page).to have_content("This is a cool store")
+    expect(page).to have_content("Pending Review")
+  end
+end

--- a/spec/features/users/user_can_initiate_a_request_for_a_new_store_spec.rb
+++ b/spec/features/users/user_can_initiate_a_request_for_a_new_store_spec.rb
@@ -17,8 +17,12 @@ describe 'Registered user can request a new store' do
 
     expect(current_path).to eq store_requests_path
 
+    sr = StoreRequest.first
+
     expect(page).to have_content("Cool Store")
-    expect(page).to have_content("This is a cool store")
-    expect(page).to have_content("Pending Review")
+    expect(page).to have_content("#{sr.id}")
+    expect(page).to have_content("#{sr.updated_at.to_formatted_s(:long_ordinal)}")
+    expect(page).to have_content("#{sr.created_at.to_formatted_s(:long_ordinal)}")
+    expect(page).to have_content("Pending")
   end
 end

--- a/spec/features/users/user_can_initiate_a_request_for_a_new_store_spec.rb
+++ b/spec/features/users/user_can_initiate_a_request_for_a_new_store_spec.rb
@@ -25,4 +25,29 @@ describe 'Registered user can request a new store' do
     expect(page).to have_content("#{sr.created_at.to_formatted_s(:long_ordinal)}")
     expect(page).to have_content("Pending")
   end
+
+  scenario 'and Admin can also request new store' do
+    admin = create(:operator)
+    allow_any_instance_of(ApplicationController).to receive(:current_operator).and_return(admin)
+
+    visit '/'
+
+    click_on 'Request a Store'
+
+    expect(current_path).to eq new_store_request_path
+
+    fill_in 'store_request[name]', with: 'Cool Store'
+    fill_in 'store_request[description]', with: 'This is a cool store'
+    click_on 'Submit'
+
+    expect(current_path).to eq store_requests_path
+
+    sr = StoreRequest.first
+
+    expect(page).to have_content("Cool Store")
+    expect(page).to have_content("#{sr.id}")
+    expect(page).to have_content("#{sr.updated_at.to_formatted_s(:long_ordinal)}")
+    expect(page).to have_content("#{sr.created_at.to_formatted_s(:long_ordinal)}")
+    expect(page).to have_content("Pending")
+  end
 end

--- a/spec/services/store_request_converter_spec.rb
+++ b/spec/services/store_request_converter_spec.rb
@@ -1,0 +1,18 @@
+require 'rails_helper'
+
+describe StoreRequestConverter do
+  it '.declined' do
+    request = create(:store_request)
+    converter = StoreRequestConverter.new(request)
+    declined = converter.declined
+    expect(declined).to be true
+  end
+
+  it '.approved' do
+    user = create(:user)
+    request = create(:store_request, user: user)
+    converter = StoreRequestConverter.new(request)
+    approved = converter.approved
+    expect(approved).to be true
+  end
+end


### PR DESCRIPTION
Additions: 
Added functionality for users or platform admins creating new_store requests and platform admin having the ability to approve or decline those requests. Feature and unit tests as well

User Story:
20 - Requests for new store
18 - Platform Admin - new store approval

Concerns (code location):
n/a

Mentions to collaborators:
@amhursh

Notes(if applicable):
n/a


